### PR TITLE
feat: Add workflow to publish OpenAPI specs to ReadMe

### DIFF
--- a/.github/workflows/publish-openapi-readme.yaml
+++ b/.github/workflows/publish-openapi-readme.yaml
@@ -1,0 +1,30 @@
+name: Publish OpenAPI to ReadMe
+
+on:
+  push:
+    branches: [v1.0]
+    paths:
+      - 'reference/*.yaml'
+      - '!reference/_order.yaml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    strategy:
+      fail-fast: false
+      matrix:
+        spec:
+          - reference/app-provisioning-api-for-partners.yaml
+          - reference/custom-rendering-api.yaml
+          - reference/data-sync.yaml
+          - reference/oas_create_tenant.yaml
+          - reference/oas_get_tenant.yaml
+          - reference/oas_redirect.yaml
+          - reference/oas_session.yaml
+          - reference/oas_update_tenant.yaml
+    uses: recurly/pipeline-configs/.github/workflows/publish-openapi-readme.yaml@master
+    with:
+      spec-path: ${{ matrix.spec }}
+      readme-version: v1.0
+    secrets:
+      readme-api-key: ${{ secrets.ENGAGE_RDME_API_TOKEN }}


### PR DESCRIPTION
## Description
Adds a caller workflow that publishes all 8 OpenAPI spec files to ReadMe on push to v1.0 or manual dispatch. Uses a reusable workflow for OpenAPI publishing.

- Matrix strategy fans out across all 8 spec files with `fail-fast: false`
- Triggers on push to `v1.0` when `reference/*.yaml` changes (excludes `_order.yaml`)
- Supports `workflow_dispatch` for manual/bulk runs
- Uses `ENGAGE_RDME_API_TOKEN` repo secret for ReadMe authentication

## Prerequisites
- `ENGAGE_RDME_API_TOKEN` secret must be set on this repo

## Testing
Trigger via workflow_dispatch after merge for initial bulk upload.