### PR TITLE
fix: Add explicit slugs to match existing ReadMe definitions

### DIFF
--- a/.github/workflows/publish-openapi-readme.yaml
+++ b/.github/workflows/publish-openapi-readme.yaml
@@ -14,15 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        spec:
-          - reference/app-provisioning-api-for-partners.yaml
-          - reference/custom-rendering-api.yaml
-          - reference/data-sync.yaml
-          - reference/oas_create_tenant.yaml
-          - reference/oas_get_tenant.yaml
-          - reference/oas_redirect.yaml
-          - reference/oas_session.yaml
-          - reference/oas_update_tenant.yaml
+        include:
+          - spec: reference/app-provisioning-api-for-partners.yaml
+            slug: app-provisioning-api-for-partners.yaml
+          - spec: reference/custom-rendering-api.yaml
+            slug: custom-rendering-api.yaml
+          - spec: reference/data-sync.yaml
+            slug: data-sync.yaml
+          - spec: reference/oas_create_tenant.yaml
+            slug: oas_create_tenant.yaml
+          - spec: reference/oas_get_tenant.yaml
+            slug: oas_get_tenant.yaml
+          - spec: reference/oas_redirect.yaml
+            slug: oas_redirect.yaml
+          - spec: reference/oas_session.yaml
+            slug: oas_session.yaml
+          - spec: reference/oas_update_tenant.yaml
+            slug: oas_update_tenant.yaml
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -34,4 +42,5 @@ jobs:
             openapi upload ${{ matrix.spec }}
             --key=${{ secrets.ENGAGE_RDME_API_TOKEN }}
             --branch=v1.0
+            --slug=${{ matrix.slug }}
             --confirm-overwrite


### PR DESCRIPTION
## Description
Adds explicit `--slug` flags to prevent duplicate API definitions. Without slugs, rdme infers from the file path (e.g., `reference/app-provisioning-api-for-partners.yaml` becomes `referenceapp-provisioning-api-for-partners.yaml`), creating duplicates instead of updating existing definitions.

Also updates `ENGAGE_RDME_API_TOKEN` secret to use the correct Engage project key.

## Prerequisites
- Delete the 8 `reference*` prefixed duplicate definitions from the Engage ReadMe dashboard before triggering workflow_dispatch
- Update `ENGAGE_RDME_API_TOKEN` secret to the correct Engage project API key

## Testing
Trigger via workflow_dispatch after merge and cleanup.